### PR TITLE
feat: add basic rotation for 270 degrees

### DIFF
--- a/i75/graphics.py
+++ b/i75/graphics.py
@@ -34,7 +34,7 @@ class Graphics:
                  color_order: hub75.ColorOrder
                  = hub75.COLOR_ORDER_RGB) -> None:
         self._driver = picographics.PicoGraphics(display_type)
-        self.rotate = rotate
+        self.rotate = rotate #for now only accept 90,180, 270
 
         self.width, self.height = self._driver.get_bounds()
         self.hub75 = hub75.Hub75(self.width,
@@ -113,12 +113,26 @@ class Graphics:
                 self.pixel(x, y)
 
     def pixel(self, x: int, y: int) -> None:
+        if self.rotate != 0:
+            x, y = self._rotate_pixels(x, y)
+
         if x >= 0 and x < self.width and y >= 0 and y < self.height:
             self._driver.pixel(x, y)
 
     def __pixel_reverse(self, x: int, y: int) -> None:
+        if self.rotate != 0:
+            x, y = self._rotate_pixels(x, y)
+
         if x >= 0 and x < self.width and y >= 0 and y < self.height:
             self._driver.pixel(y, x)
+
+    def _rotate_pixels(self, x: int, y: int) -> Tuple[int, int]:
+        x_h = x
+        y_h = y
+        if self.rotate == 270:
+            x_h = y
+            y_h = self.height - 1 - x
+        return x_h, y_h
 
     def update(self) -> None:
         self.hub75.update(self._driver)


### PR DESCRIPTION
More angles to be added once we agree on this concept being ok.

This is essentially what I've had to do to be able to create a vertical output using 128x64 display.

I've just moved the logic to the lib.

Its not ideal, but the hub75 driver doesn't support rotation so you have to do it on the buffer level. I think we'd want to only support 0/90/180/270 which is still better than nothing.

Let me know what you think.