### PR TITLE
feat: add clear function

### DIFF
--- a/i75/emulated/picographics.py
+++ b/i75/emulated/picographics.py
@@ -64,6 +64,11 @@ class PicoGraphics:
                 last_coord = (px, py)
                 self.pixel(px, py)
 
+    def clear(self) -> None:
+        for y in range(self.display_type.height):
+            for x in range(self.display_type.width):
+                self._buffer[y][x] = self.pen.as_tuple()
+
     def pixel(self, x: int, y: int) -> None:
         self._buffer[y][x] = self.pen.as_tuple()
 

--- a/i75/graphics.py
+++ b/i75/graphics.py
@@ -112,6 +112,9 @@ class Graphics:
             for y in range(tl_y, br_y):
                 self.pixel(x, y)
 
+    def clear(self) -> None:
+        self._driver.clear()
+
     def pixel(self, x: int, y: int) -> None:
         if x >= 0 and x < self.width and y >= 0 and y < self.height:
             self._driver.pixel(x, y)


### PR DESCRIPTION
Add in a clear function.

pygame has its own fill function, but then you have to deal with clearing the buffer anyway.

native hub75 has a clear function so its only the emulated function that isn't necessarily doing it the most performant way but like I say, you have to run clear(), and then update() on native anyway, and in emulated you'd need to clear down the buffer contents anyway.

fixes #96 